### PR TITLE
Fix CI Swift tools compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
## Summary
- lower `Package.swift` from Swift tools 6.2 to 6.1
- match the current GitHub Actions macOS runner toolchain so CI can build the package again

## Validation
- swift build
- swift test