### PR TITLE
Fix Swift 6.1 branding cache CI failure

### DIFF
--- a/Sources/markiiupMac/Views/MarkiiupBrandingView.swift
+++ b/Sources/markiiupMac/Views/MarkiiupBrandingView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 
+@MainActor
 private enum MarkiiupBrandResources {
     static let catImage: NSImage? = {
         guard let url = Bundle.main.url(forResource: "markiiup_cat", withExtension: "png") else {


### PR DESCRIPTION
## Summary
- isolate the branding image cache on the main actor
- keep the cached AppKit image load behavior intact
- unblock Swift 6.1 GitHub Actions builds on main

## Testing
- swift build
- swift test